### PR TITLE
Add option for uncompressed

### DIFF
--- a/cpp/Base58Check.hpp
+++ b/cpp/Base58Check.hpp
@@ -25,10 +25,11 @@ class Base58Check final {
 	public: static void pubkeyHashToBase58Check(const std::uint8_t pubkeyHash[Ripemd160::HASH_LEN], std::uint8_t version, char outStr[36]);
 	
 	
-	// Exports the given private key with the given version prefix byte as compressed WIF.
+	// Exports the given private key with the given version prefix byte as WIF.
+	// If the compressed flag is set, the WIF will be compressed.
 	// The outStr array must have length >= 53 (including null terminator).
 	// The output text length is between 38 and 52 characters, inclusive. Not constant-time.
-	public: static void privateKeyToBase58Check(const Uint256 &privKey, std::uint8_t version, char outStr[53]);
+	public: static void privateKeyToBase58Check(const Uint256 &privKey, std::uint8_t version, bool compressed, char outStr[53]);
 	
 	
 	// Parses the given public address string. If the syntax and check digits are correct, then the
@@ -38,10 +39,10 @@ class Base58Check final {
 	
 	
 	// Parses the given compressed WIF string. If the syntax and check digits are correct, then the private key
-	// Uint256 is set to the decoded value, the version byte is set if not null, and true is returned.
-	// Otherwise the Uint256 and version are unchanged, and false is returned. Not constant-time.
+	// Uint256 is set to the decoded value, the version byte is set if not null, the compressed flag is set if not null,
+	// and true is returned. Otherwise the Uint256 and version are unchanged, and false is returned. Not constant-time.
 	// Note that the decoded integer may be outside the normal private key range of [1, CurvePoint::ORDER).
-	public: static bool privateKeyFromBase58Check(const char wifStr[53], Uint256 &outPrivKey, std::uint8_t *version);
+	public: static bool privateKeyFromBase58Check(const char wifStr[53], Uint256 &outPrivKey, std::uint8_t *version, bool* compressed);
 	
 	
 	// Computes the 4-byte hash of the given byte array and converts the concatenated data to Base58Check.


### PR DESCRIPTION
Added compressed flag to privateKeyToBase58Check and privateKeyFromBase58Check.

This implementation passes all of the tests in our project.  I believe it to be correct.

Please let me know if you prefer any changes.

Thank you for your consideration.