### PR TITLE
Update Makefile

### DIFF
--- a/cpp/CurvePoint.cpp
+++ b/cpp/CurvePoint.cpp
@@ -303,6 +303,24 @@ void CurvePoint::toCompressedPoint(uint8_t output[33]) const {
 	x.getBigEndianBytes(&output[1]);
 }
 
+void CurvePoint::toAddress(char output[36], bool is_compressed, bool is_main_net) const {
+	assert(output != nullptr);
+	if (!is_compressed) {
+		std::uint8_t b[65];
+		b[0] = 0x04;
+		x.getBigEndianBytes(&b[1]);
+		y.getBigEndianBytes(&b[33]);
+		std::uint8_t actualHash[Ripemd160::HASH_LEN];
+		Ripemd160::getHash(Sha256::getHash(b, 65).value, 32, actualHash);
+		Base58Check::pubkeyHashToBase58Check(actualHash, is_main_net ? 0x00 : 0x6F, output); //testnet  0x6F
+	} else {
+		std::uint8_t b[33];
+		toCompressedPoint(b);
+		std::uint8_t actualHash[Ripemd160::HASH_LEN];
+		Ripemd160::getHash(Sha256::getHash(b, 33).value, 32, actualHash);
+		Base58Check::pubkeyHashToBase58Check(actualHash, is_main_net ? 0x00 : 0x6F, output); //testnet  0x6F
+	}
+}
 
 CurvePoint CurvePoint::privateExponentToPublicPoint(const Uint256 &privExp) {
 	assert((Uint256::ZERO < privExp) & (privExp < CurvePoint::ORDER));

--- a/cpp/CurvePoint.hpp
+++ b/cpp/CurvePoint.hpp
@@ -108,6 +108,7 @@ class CurvePoint final {
 	// This point needs to be normalized before the method is called. Constant-time with respect to this value.
 	public: void toCompressedPoint(std::uint8_t output[33]) const;
 	
+	public: void toAddress(char output[36], bool is_compressed, bool is_main_net) const;
 	
 	/*---- Static functions ----*/
 	

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -23,7 +23,8 @@
 # Mandatory compiler flags
 CXXFLAGS += -std=c++11
 # Diagnostics. Adding '-fsanitize=address' is helpful for most versions of Clang and newer versions of GCC.
-CXXFLAGS += -Wall -fsanitize=undefined
+# add  -fsanitize-undefined-trap-on-error to use UBSan without its library
+CXXFLAGS += -Wall -fsanitize=undefined  -fsanitize-undefined-trap-on-error
 # Optimization level
 CXXFLAGS += -O1
 # Choose "pure-cpp" or "x8664"


### PR DESCRIPTION
To avoid the following error under msys2/mingw. It seems msys2 does not provide ubsan. 
$ make
g++ -std=c++11 -Wall -fsanitize=undefined -O1 -o Base58CheckTest Base58CheckTest.o -L . -l bitcoincrypto
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/9.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: cannot find -lubsan
collect2.exe: error: ld returned 1 exit status
make: *** [Makefile:73: Base58CheckTest] Error 1
